### PR TITLE
增加消息类与UnityEngine中的类

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 Debug/
 Release/
 obj/
+Bin/
 
 # unity files #  
 ######################

--- a/MMOServer/Server/ET.Core/Base/UnityEngine/Bounds.cs
+++ b/MMOServer/Server/ET.Core/Base/UnityEngine/Bounds.cs
@@ -1,0 +1,115 @@
+// Unity C# reference source
+// Copyright (c) Unity Technologies. For terms of use, see
+// https://unity3d.com/legal/licenses/Unity_Reference_Only_License
+
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using scm = System.ComponentModel;
+
+namespace UnityEngine
+{
+    [Serializable]
+    public partial struct Bounds : IEquatable<Bounds>
+    {
+        private Vector3 m_Center;
+        private Vector3 m_Extents;
+
+        // Creates new Bounds with a given /center/ and total /size/. Bound ::ref::extents will be half the given size.
+        public Bounds(Vector3 center, Vector3 size)
+        {
+            m_Center = center;
+            m_Extents = size * 0.5F;
+        }
+
+        // used to allow Bounds to be used as keys in hash tables
+        public override int GetHashCode()
+        {
+            return center.GetHashCode() ^ (extents.GetHashCode() << 2);
+        }
+
+        // also required for being able to use Vector4s as keys in hash tables
+        public override bool Equals(object other)
+        {
+            if (!(other is Bounds)) return false;
+
+            return Equals((Bounds)other);
+        }
+
+        public bool Equals(Bounds other)
+        {
+            return center.Equals(other.center) && extents.Equals(other.extents);
+        }
+
+        // The center of the bounding box.
+        public Vector3 center { get { return m_Center; } set { m_Center = value; } }
+
+        // The total size of the box. This is always twice as large as the ::ref::extents.
+        public Vector3 size { get { return m_Extents * 2.0F; } set { m_Extents = value * 0.5F; } }
+
+        // The extents of the box. This is always half of the ::ref::size.
+        public Vector3 extents { get { return m_Extents; } set { m_Extents = value; } }
+
+        // The minimal point of the box. This is always equal to ''center-extents''.
+        public Vector3 min { get { return center - extents; } set { SetMinMax(value, max); } }
+
+        // The maximal point of the box. This is always equal to ''center+extents''.
+        public Vector3 max { get { return center + extents; } set { SetMinMax(min, value); } }
+
+        //*undoc*
+        public static bool operator==(Bounds lhs, Bounds rhs)
+        {
+            // Returns false in the presence of NaN values.
+            return (lhs.center == rhs.center && lhs.extents == rhs.extents);
+        }
+
+        //*undoc*
+        public static bool operator!=(Bounds lhs, Bounds rhs)
+        {
+            // Returns true in the presence of NaN values.
+            return !(lhs == rhs);
+        }
+
+        // Sets the bounds to the /min/ and /max/ value of the box.
+        public void SetMinMax(Vector3 min, Vector3 max)
+        {
+            extents = (max - min) * 0.5F;
+            center = min + extents;
+        }
+
+        // Grows the Bounds to include the /point/.
+        public void Encapsulate(Vector3 point)
+        {
+            SetMinMax(Vector3.Min(min, point), Vector3.Max(max, point));
+        }
+
+        // Grows the Bounds to include the /Bounds/.
+        public void Encapsulate(Bounds bounds)
+        {
+            Encapsulate(bounds.center - bounds.extents);
+            Encapsulate(bounds.center + bounds.extents);
+        }
+
+        // Expand the bounds by increasing its /size/ by /amount/ along each side.
+        public void Expand(float amount)
+        {
+            amount *= .5f;
+            extents += new Vector3(amount, amount, amount);
+        }
+
+        // Expand the bounds by increasing its /size/ by /amount/ along each side.
+        public void Expand(Vector3 amount)
+        {
+            extents += amount * .5f;
+        }
+
+        // Does another bounding box intersect with this bounding box?
+        public bool Intersects(Bounds bounds)
+        {
+            return (min.x <= bounds.max.x) && (max.x >= bounds.min.x) &&
+                (min.y <= bounds.max.y) && (max.y >= bounds.min.y) &&
+                (min.z <= bounds.max.z) && (max.z >= bounds.min.z);
+        }
+
+    }
+}

--- a/MMOServer/Server/ET.Core/Base/UnityEngine/Quaternion.cs
+++ b/MMOServer/Server/ET.Core/Base/UnityEngine/Quaternion.cs
@@ -214,6 +214,15 @@ namespace UnityEngine
             quaternion.w = (float) ((double) num9 * (double) num6 * (double) num3 + (double) num8 * (double) num5 * (double) num2);
             return quaternion;
         }
+
+        public static Vector3 QuaternionToEuler(Quaternion quat)
+        {
+            Matrix3x3 m = QuaternionToMatrix(quat);
+            Vector3 euler = MatrixToEuler(m);
+
+            //弧度转角度
+            return Mathf.Rad2Deg(euler);
+        }
         
         public static Quaternion Euler(Vector3 eulerAngle)
         {
@@ -275,15 +284,6 @@ namespace UnityEngine
             m.Data[8] = 1.0f - (xx + yy);
 
             return m;
-        }
-        
-        public static Vector3 QuaternionToEuler(Quaternion quat)
-        {
-            Matrix3x3 m = QuaternionToMatrix(quat);
-            Vector3 euler = MatrixToEuler(m);
-
-            //弧度转角度
-            return Mathf.Rad2Deg(euler);
         }
         
         private static Vector3 MakePositive(Vector3 euler)

--- a/MMOServer/Server/ET.Core/Base/UnityEngine/Vector3.cs
+++ b/MMOServer/Server/ET.Core/Base/UnityEngine/Vector3.cs
@@ -40,6 +40,44 @@ namespace UnityEngine
             this.z = z;
         }
 
+        public static Vector3 MoveTowards(Vector3 current, Vector3 target, float maxDistanceDelta)
+        {
+            // avoid vector ops because current scripting backends are terrible at inlining
+            float toVector_x = target.x - current.x;
+            float toVector_y = target.y - current.y;
+            float toVector_z = target.z - current.z;
+
+            float sqdist = toVector_x * toVector_x + toVector_y * toVector_y + toVector_z * toVector_z;
+
+            if (sqdist == 0 || (maxDistanceDelta >= 0 && sqdist <= maxDistanceDelta * maxDistanceDelta))
+                return target;
+            var dist = (float)Math.Sqrt(sqdist);
+
+            return new Vector3(current.x + toVector_x / dist * maxDistanceDelta,
+                current.y + toVector_y / dist * maxDistanceDelta,
+                current.z + toVector_z / dist * maxDistanceDelta);
+        }
+
+        // Returns a copy of /vector/ with its magnitude clamped to /maxLength/.
+        public static Vector3 ClampMagnitude(Vector3 vector, float maxLength)
+        {
+            float sqrmag = vector.sqrMagnitude;
+            if (sqrmag > maxLength * maxLength)
+            {
+                float mag = (float)Math.Sqrt(sqrmag);
+                //these intermediate variables force the intermediate result to be
+                //of float precision. without this, the intermediate result can be of higher
+                //precision, which changes behavior.
+                float normalized_x = vector.x / mag;
+                float normalized_y = vector.y / mag;
+                float normalized_z = vector.z / mag;
+                return new Vector3(normalized_x * maxLength,
+                    normalized_y * maxLength,
+                    normalized_z * maxLength);
+            }
+            return vector;
+        }
+
         public override string ToString()
         {
             CultureInfo currentCulture = CultureInfo.CurrentCulture;

--- a/MMOServer/Server/ET.Core/Module/Message/OuterMessage.cs
+++ b/MMOServer/Server/ET.Core/Module/Message/OuterMessage.cs
@@ -319,117 +319,9 @@ namespace ETModel {
 
   }
 
-  public partial class Sync_MoveMessage : pb::IMessage {
-    private static readonly pb::MessageParser<Sync_MoveMessage> _parser = new pb::MessageParser<Sync_MoveMessage>(() => (Sync_MoveMessage)MessagePool.Instance.Fetch(typeof(Sync_MoveMessage)));
-    public static pb::MessageParser<Sync_MoveMessage> Parser { get { return _parser; } }
-
-    private int rpcId_;
-    public int RpcId {
-      get { return rpcId_; }
-      set {
-        rpcId_ = value;
-      }
-    }
-
-    private long actorId_;
-    public long ActorId {
-      get { return actorId_; }
-      set {
-        actorId_ = value;
-      }
-    }
-
-    private long unitId_;
-    public long UnitId {
-      get { return unitId_; }
-      set {
-        unitId_ = value;
-      }
-    }
-
-    private global::ETModel.MoveInfo moveInfo_;
-    public global::ETModel.MoveInfo MoveInfo {
-      get { return moveInfo_; }
-      set {
-        moveInfo_ = value;
-      }
-    }
-
-    public void WriteTo(pb::CodedOutputStream output) {
-      if (UnitId != 0L) {
-        output.WriteRawTag(8);
-        output.WriteInt64(UnitId);
-      }
-      if (moveInfo_ != null) {
-        output.WriteRawTag(18);
-        output.WriteMessage(MoveInfo);
-      }
-      if (RpcId != 0) {
-        output.WriteRawTag(208, 5);
-        output.WriteInt32(RpcId);
-      }
-      if (ActorId != 0L) {
-        output.WriteRawTag(232, 5);
-        output.WriteInt64(ActorId);
-      }
-    }
-
-    public int CalculateSize() {
-      int size = 0;
-      if (RpcId != 0) {
-        size += 2 + pb::CodedOutputStream.ComputeInt32Size(RpcId);
-      }
-      if (ActorId != 0L) {
-        size += 2 + pb::CodedOutputStream.ComputeInt64Size(ActorId);
-      }
-      if (UnitId != 0L) {
-        size += 1 + pb::CodedOutputStream.ComputeInt64Size(UnitId);
-      }
-      if (moveInfo_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(MoveInfo);
-      }
-      return size;
-    }
-
-    public void MergeFrom(pb::CodedInputStream input) {
-      unitId_ = 0;
-      if (moveInfo_ != null) MessagePool.Instance.Recycle(moveInfo_); moveInfo_ = null;
-      rpcId_ = 0;
-      actorId_ = 0;
-      uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-        switch(tag) {
-          default:
-            input.SkipLastField();
-            break;
-          case 8: {
-            UnitId = input.ReadInt64();
-            break;
-          }
-          case 18: {
-            if (moveInfo_ == null) {
-              moveInfo_ = new global::ETModel.MoveInfo();
-            }
-            input.ReadMessage(moveInfo_);
-            break;
-          }
-          case 720: {
-            RpcId = input.ReadInt32();
-            break;
-          }
-          case 744: {
-            ActorId = input.ReadInt64();
-            break;
-          }
-        }
-      }
-    }
-
-  }
-
-  public partial class State_FrameMessage : pb::IMessage {
-    private static readonly pb::MessageParser<State_FrameMessage> _parser = new pb::MessageParser<State_FrameMessage>(() => (State_FrameMessage)MessagePool.Instance.Fetch(typeof(State_FrameMessage)));
-    public static pb::MessageParser<State_FrameMessage> Parser { get { return _parser; } }
+  public partial class C2M_SelectTarget : pb::IMessage {
+    private static readonly pb::MessageParser<C2M_SelectTarget> _parser = new pb::MessageParser<C2M_SelectTarget>(() => (C2M_SelectTarget)MessagePool.Instance.Fetch(typeof(C2M_SelectTarget)));
+    public static pb::MessageParser<C2M_SelectTarget> Parser { get { return _parser; } }
 
     private int rpcId_;
     public int RpcId {
@@ -455,18 +347,18 @@ namespace ETModel {
       }
     }
 
-    private global::ETModel.MoveInfo moveInfo_;
-    public global::ETModel.MoveInfo MoveInfo {
-      get { return moveInfo_; }
+    private int targetNetId_;
+    public int TargetNetId {
+      get { return targetNetId_; }
       set {
-        moveInfo_ = value;
+        targetNetId_ = value;
       }
     }
 
     public void WriteTo(pb::CodedOutputStream output) {
-      if (moveInfo_ != null) {
-        output.WriteRawTag(10);
-        output.WriteMessage(MoveInfo);
+      if (TargetNetId != 0) {
+        output.WriteRawTag(8);
+        output.WriteInt32(TargetNetId);
       }
       if (RpcId != 0) {
         output.WriteRawTag(208, 5);
@@ -493,14 +385,14 @@ namespace ETModel {
       if (Id != 0L) {
         size += 2 + pb::CodedOutputStream.ComputeInt64Size(Id);
       }
-      if (moveInfo_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(MoveInfo);
+      if (TargetNetId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(TargetNetId);
       }
       return size;
     }
 
     public void MergeFrom(pb::CodedInputStream input) {
-      if (moveInfo_ != null) MessagePool.Instance.Recycle(moveInfo_); moveInfo_ = null;
+      targetNetId_ = 0;
       rpcId_ = 0;
       actorId_ = 0;
       id_ = 0;
@@ -510,11 +402,8 @@ namespace ETModel {
           default:
             input.SkipLastField();
             break;
-          case 10: {
-            if (moveInfo_ == null) {
-              moveInfo_ = new global::ETModel.MoveInfo();
-            }
-            input.ReadMessage(moveInfo_);
+          case 8: {
+            TargetNetId = input.ReadInt32();
             break;
           }
           case 720: {
@@ -535,9 +424,25 @@ namespace ETModel {
 
   }
 
-  public partial class MoveInfo : pb::IMessage {
-    private static readonly pb::MessageParser<MoveInfo> _parser = new pb::MessageParser<MoveInfo>(() => (MoveInfo)MessagePool.Instance.Fetch(typeof(MoveInfo)));
-    public static pb::MessageParser<MoveInfo> Parser { get { return _parser; } }
+  public partial class M2C_SelectTarget : pb::IMessage {
+    private static readonly pb::MessageParser<M2C_SelectTarget> _parser = new pb::MessageParser<M2C_SelectTarget>(() => (M2C_SelectTarget)MessagePool.Instance.Fetch(typeof(M2C_SelectTarget)));
+    public static pb::MessageParser<M2C_SelectTarget> Parser { get { return _parser; } }
+
+    private long actorId_;
+    public long ActorId {
+      get { return actorId_; }
+      set {
+        actorId_ = value;
+      }
+    }
+
+    private long id_;
+    public long Id {
+      get { return id_; }
+      set {
+        id_ = value;
+      }
+    }
 
     private long unitId_;
     public long UnitId {
@@ -547,19 +452,433 @@ namespace ETModel {
       }
     }
 
-    private pb::ByteString route_ = pb::ByteString.Empty;
-    public pb::ByteString Route {
-      get { return route_; }
+    private int targetNetId_;
+    public int TargetNetId {
+      get { return targetNetId_; }
       set {
-        route_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+        targetNetId_ = value;
       }
     }
 
-    private float yRotation_;
-    public float YRotation {
-      get { return yRotation_; }
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (UnitId != 0L) {
+        output.WriteRawTag(8);
+        output.WriteInt64(UnitId);
+      }
+      if (TargetNetId != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(TargetNetId);
+      }
+      if (ActorId != 0L) {
+        output.WriteRawTag(232, 5);
+        output.WriteInt64(ActorId);
+      }
+      if (Id != 0L) {
+        output.WriteRawTag(240, 5);
+        output.WriteInt64(Id);
+      }
+    }
+
+    public int CalculateSize() {
+      int size = 0;
+      if (ActorId != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(ActorId);
+      }
+      if (Id != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(Id);
+      }
+      if (UnitId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(UnitId);
+      }
+      if (TargetNetId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(TargetNetId);
+      }
+      return size;
+    }
+
+    public void MergeFrom(pb::CodedInputStream input) {
+      unitId_ = 0;
+      targetNetId_ = 0;
+      actorId_ = 0;
+      id_ = 0;
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 8: {
+            UnitId = input.ReadInt64();
+            break;
+          }
+          case 16: {
+            TargetNetId = input.ReadInt32();
+            break;
+          }
+          case 744: {
+            ActorId = input.ReadInt64();
+            break;
+          }
+          case 752: {
+            Id = input.ReadInt64();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public partial class M2C_CreateSprites : pb::IMessage {
+    private static readonly pb::MessageParser<M2C_CreateSprites> _parser = new pb::MessageParser<M2C_CreateSprites>(() => (M2C_CreateSprites)MessagePool.Instance.Fetch(typeof(M2C_CreateSprites)));
+    public static pb::MessageParser<M2C_CreateSprites> Parser { get { return _parser; } }
+
+    private long actorId_;
+    public long ActorId {
+      get { return actorId_; }
       set {
-        yRotation_ = value;
+        actorId_ = value;
+      }
+    }
+
+    private long id_;
+    public long Id {
+      get { return id_; }
+      set {
+        id_ = value;
+      }
+    }
+
+    private static readonly pb::FieldCodec<global::ETModel.SpriteInfo> _repeated_spriteInfos_codec
+        = pb::FieldCodec.ForMessage(10, global::ETModel.SpriteInfo.Parser);
+    private pbc::RepeatedField<global::ETModel.SpriteInfo> spriteInfos_ = new pbc::RepeatedField<global::ETModel.SpriteInfo>();
+    public pbc::RepeatedField<global::ETModel.SpriteInfo> SpriteInfos {
+      get { return spriteInfos_; }
+      set { spriteInfos_ = value; }
+    }
+
+    public void WriteTo(pb::CodedOutputStream output) {
+      spriteInfos_.WriteTo(output, _repeated_spriteInfos_codec);
+      if (ActorId != 0L) {
+        output.WriteRawTag(232, 5);
+        output.WriteInt64(ActorId);
+      }
+      if (Id != 0L) {
+        output.WriteRawTag(240, 5);
+        output.WriteInt64(Id);
+      }
+    }
+
+    public int CalculateSize() {
+      int size = 0;
+      if (ActorId != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(ActorId);
+      }
+      if (Id != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(Id);
+      }
+      size += spriteInfos_.CalculateSize(_repeated_spriteInfos_codec);
+      return size;
+    }
+
+    public void MergeFrom(pb::CodedInputStream input) {
+      for (int i = 0; i < spriteInfos_.Count; i++) { MessagePool.Instance.Recycle(spriteInfos_[i]); }
+      spriteInfos_.Clear();
+      actorId_ = 0;
+      id_ = 0;
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            spriteInfos_.AddEntriesFrom(input, _repeated_spriteInfos_codec);
+            break;
+          }
+          case 744: {
+            ActorId = input.ReadInt64();
+            break;
+          }
+          case 752: {
+            Id = input.ReadInt64();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public partial class SpriteInfo : pb::IMessage {
+    private static readonly pb::MessageParser<SpriteInfo> _parser = new pb::MessageParser<SpriteInfo>(() => (SpriteInfo)MessagePool.Instance.Fetch(typeof(SpriteInfo)));
+    public static pb::MessageParser<SpriteInfo> Parser { get { return _parser; } }
+
+    private string class_ = "";
+    public string Class {
+      get { return class_; }
+      set {
+        class_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    private string name_ = "";
+    public string Name {
+      get { return name_; }
+      set {
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    private string type_ = "";
+    public string Type {
+      get { return type_; }
+      set {
+        type_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    private global::ETModel.Vector3Info position_;
+    public global::ETModel.Vector3Info Position {
+      get { return position_; }
+      set {
+        position_ = value;
+      }
+    }
+
+    private float rotation_;
+    public float Rotation {
+      get { return rotation_; }
+      set {
+        rotation_ = value;
+      }
+    }
+
+    private int mapId_;
+    public int MapId {
+      get { return mapId_; }
+      set {
+        mapId_ = value;
+      }
+    }
+
+    private int taskId_;
+    public int TaskId {
+      get { return taskId_; }
+      set {
+        taskId_ = value;
+      }
+    }
+
+    private int battleState_;
+    public int BattleState {
+      get { return battleState_; }
+      set {
+        battleState_ = value;
+      }
+    }
+
+    private long pickingsId_;
+    public long PickingsId {
+      get { return pickingsId_; }
+      set {
+        pickingsId_ = value;
+      }
+    }
+
+    private int netId_;
+    public int NetId {
+      get { return netId_; }
+      set {
+        netId_ = value;
+      }
+    }
+
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (Class.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(Class);
+      }
+      if (Name.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Name);
+      }
+      if (Type.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(Type);
+      }
+      if (position_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(Position);
+      }
+      if (Rotation != 0F) {
+        output.WriteRawTag(45);
+        output.WriteFloat(Rotation);
+      }
+      if (MapId != 0) {
+        output.WriteRawTag(48);
+        output.WriteInt32(MapId);
+      }
+      if (TaskId != 0) {
+        output.WriteRawTag(56);
+        output.WriteInt32(TaskId);
+      }
+      if (BattleState != 0) {
+        output.WriteRawTag(64);
+        output.WriteInt32(BattleState);
+      }
+      if (PickingsId != 0L) {
+        output.WriteRawTag(72);
+        output.WriteInt64(PickingsId);
+      }
+      if (NetId != 0) {
+        output.WriteRawTag(80);
+        output.WriteInt32(NetId);
+      }
+    }
+
+    public int CalculateSize() {
+      int size = 0;
+      if (Class.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Class);
+      }
+      if (Name.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
+      if (Type.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Type);
+      }
+      if (position_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Position);
+      }
+      if (Rotation != 0F) {
+        size += 1 + 4;
+      }
+      if (MapId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(MapId);
+      }
+      if (TaskId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(TaskId);
+      }
+      if (BattleState != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(BattleState);
+      }
+      if (PickingsId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(PickingsId);
+      }
+      if (NetId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(NetId);
+      }
+      return size;
+    }
+
+    public void MergeFrom(pb::CodedInputStream input) {
+      class_ = "";
+      name_ = "";
+      type_ = "";
+      if (position_ != null) MessagePool.Instance.Recycle(position_); position_ = null;
+      rotation_ = 0f;
+      mapId_ = 0;
+      taskId_ = 0;
+      battleState_ = 0;
+      pickingsId_ = 0;
+      netId_ = 0;
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 10: {
+            Class = input.ReadString();
+            break;
+          }
+          case 18: {
+            Name = input.ReadString();
+            break;
+          }
+          case 26: {
+            Type = input.ReadString();
+            break;
+          }
+          case 34: {
+            if (position_ == null) {
+              position_ = new global::ETModel.Vector3Info();
+            }
+            input.ReadMessage(position_);
+            break;
+          }
+          case 45: {
+            Rotation = input.ReadFloat();
+            break;
+          }
+          case 48: {
+            MapId = input.ReadInt32();
+            break;
+          }
+          case 56: {
+            TaskId = input.ReadInt32();
+            break;
+          }
+          case 64: {
+            BattleState = input.ReadInt32();
+            break;
+          }
+          case 72: {
+            PickingsId = input.ReadInt64();
+            break;
+          }
+          case 80: {
+            NetId = input.ReadInt32();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public partial class C2M_Input_Move : pb::IMessage {
+    private static readonly pb::MessageParser<C2M_Input_Move> _parser = new pb::MessageParser<C2M_Input_Move>(() => (C2M_Input_Move)MessagePool.Instance.Fetch(typeof(C2M_Input_Move)));
+    public static pb::MessageParser<C2M_Input_Move> Parser { get { return _parser; } }
+
+    private int rpcId_;
+    public int RpcId {
+      get { return rpcId_; }
+      set {
+        rpcId_ = value;
+      }
+    }
+
+    private long actorId_;
+    public long ActorId {
+      get { return actorId_; }
+      set {
+        actorId_ = value;
+      }
+    }
+
+    private long id_;
+    public long Id {
+      get { return id_; }
+      set {
+        id_ = value;
+      }
+    }
+
+    private long unitId_;
+    public long UnitId {
+      get { return unitId_; }
+      set {
+        unitId_ = value;
+      }
+    }
+
+    private int frame_;
+    public int Frame {
+      get { return frame_; }
+      set {
+        frame_ = value;
       }
     }
 
@@ -571,6 +890,169 @@ namespace ETModel {
       }
     }
 
+    private global::ETModel.Vector3Info movePosition_;
+    public global::ETModel.Vector3Info MovePosition {
+      get { return movePosition_; }
+      set {
+        movePosition_ = value;
+      }
+    }
+
+    private float yRotation_;
+    public float YRotation {
+      get { return yRotation_; }
+      set {
+        yRotation_ = value;
+      }
+    }
+
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (UnitId != 0L) {
+        output.WriteRawTag(8);
+        output.WriteInt64(UnitId);
+      }
+      if (Frame != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Frame);
+      }
+      if (State != 0) {
+        output.WriteRawTag(24);
+        output.WriteEnum((int) State);
+      }
+      if (movePosition_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(MovePosition);
+      }
+      if (YRotation != 0F) {
+        output.WriteRawTag(45);
+        output.WriteFloat(YRotation);
+      }
+      if (RpcId != 0) {
+        output.WriteRawTag(208, 5);
+        output.WriteInt32(RpcId);
+      }
+      if (ActorId != 0L) {
+        output.WriteRawTag(232, 5);
+        output.WriteInt64(ActorId);
+      }
+      if (Id != 0L) {
+        output.WriteRawTag(240, 5);
+        output.WriteInt64(Id);
+      }
+    }
+
+    public int CalculateSize() {
+      int size = 0;
+      if (RpcId != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeInt32Size(RpcId);
+      }
+      if (ActorId != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(ActorId);
+      }
+      if (Id != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(Id);
+      }
+      if (UnitId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(UnitId);
+      }
+      if (Frame != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Frame);
+      }
+      if (State != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) State);
+      }
+      if (movePosition_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(MovePosition);
+      }
+      if (YRotation != 0F) {
+        size += 1 + 4;
+      }
+      return size;
+    }
+
+    public void MergeFrom(pb::CodedInputStream input) {
+      unitId_ = 0;
+      frame_ = 0;
+      if (movePosition_ != null) MessagePool.Instance.Recycle(movePosition_); movePosition_ = null;
+      yRotation_ = 0f;
+      rpcId_ = 0;
+      actorId_ = 0;
+      id_ = 0;
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 8: {
+            UnitId = input.ReadInt64();
+            break;
+          }
+          case 16: {
+            Frame = input.ReadInt32();
+            break;
+          }
+          case 24: {
+            state_ = (global::ETModel.StateInfo) input.ReadEnum();
+            break;
+          }
+          case 34: {
+            if (movePosition_ == null) {
+              movePosition_ = new global::ETModel.Vector3Info();
+            }
+            input.ReadMessage(movePosition_);
+            break;
+          }
+          case 45: {
+            YRotation = input.ReadFloat();
+            break;
+          }
+          case 720: {
+            RpcId = input.ReadInt32();
+            break;
+          }
+          case 744: {
+            ActorId = input.ReadInt64();
+            break;
+          }
+          case 752: {
+            Id = input.ReadInt64();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public partial class M2C_Result_Move : pb::IMessage {
+    private static readonly pb::MessageParser<M2C_Result_Move> _parser = new pb::MessageParser<M2C_Result_Move>(() => (M2C_Result_Move)MessagePool.Instance.Fetch(typeof(M2C_Result_Move)));
+    public static pb::MessageParser<M2C_Result_Move> Parser { get { return _parser; } }
+
+    private long actorId_;
+    public long ActorId {
+      get { return actorId_; }
+      set {
+        actorId_ = value;
+      }
+    }
+
+    private long id_;
+    public long Id {
+      get { return id_; }
+      set {
+        id_ = value;
+      }
+    }
+
+    private long unitId_;
+    public long UnitId {
+      get { return unitId_; }
+      set {
+        unitId_ = value;
+      }
+    }
+
     private int frame_;
     public int Frame {
       get { return frame_; }
@@ -578,6 +1060,847 @@ namespace ETModel {
         frame_ = value;
       }
     }
+
+    private global::ETModel.StateInfo state_ = 0;
+    public global::ETModel.StateInfo State {
+      get { return state_; }
+      set {
+        state_ = value;
+      }
+    }
+
+    private global::ETModel.Vector3Info movePosition_;
+    public global::ETModel.Vector3Info MovePosition {
+      get { return movePosition_; }
+      set {
+        movePosition_ = value;
+      }
+    }
+
+    private float yRotation_;
+    public float YRotation {
+      get { return yRotation_; }
+      set {
+        yRotation_ = value;
+      }
+    }
+
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (UnitId != 0L) {
+        output.WriteRawTag(8);
+        output.WriteInt64(UnitId);
+      }
+      if (Frame != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Frame);
+      }
+      if (State != 0) {
+        output.WriteRawTag(24);
+        output.WriteEnum((int) State);
+      }
+      if (movePosition_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(MovePosition);
+      }
+      if (YRotation != 0F) {
+        output.WriteRawTag(45);
+        output.WriteFloat(YRotation);
+      }
+      if (ActorId != 0L) {
+        output.WriteRawTag(232, 5);
+        output.WriteInt64(ActorId);
+      }
+      if (Id != 0L) {
+        output.WriteRawTag(240, 5);
+        output.WriteInt64(Id);
+      }
+    }
+
+    public int CalculateSize() {
+      int size = 0;
+      if (ActorId != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(ActorId);
+      }
+      if (Id != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(Id);
+      }
+      if (UnitId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(UnitId);
+      }
+      if (Frame != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Frame);
+      }
+      if (State != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) State);
+      }
+      if (movePosition_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(MovePosition);
+      }
+      if (YRotation != 0F) {
+        size += 1 + 4;
+      }
+      return size;
+    }
+
+    public void MergeFrom(pb::CodedInputStream input) {
+      unitId_ = 0;
+      frame_ = 0;
+      if (movePosition_ != null) MessagePool.Instance.Recycle(movePosition_); movePosition_ = null;
+      yRotation_ = 0f;
+      actorId_ = 0;
+      id_ = 0;
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 8: {
+            UnitId = input.ReadInt64();
+            break;
+          }
+          case 16: {
+            Frame = input.ReadInt32();
+            break;
+          }
+          case 24: {
+            state_ = (global::ETModel.StateInfo) input.ReadEnum();
+            break;
+          }
+          case 34: {
+            if (movePosition_ == null) {
+              movePosition_ = new global::ETModel.Vector3Info();
+            }
+            input.ReadMessage(movePosition_);
+            break;
+          }
+          case 45: {
+            YRotation = input.ReadFloat();
+            break;
+          }
+          case 744: {
+            ActorId = input.ReadInt64();
+            break;
+          }
+          case 752: {
+            Id = input.ReadInt64();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public partial class C2M_Input_UseSkill : pb::IMessage {
+    private static readonly pb::MessageParser<C2M_Input_UseSkill> _parser = new pb::MessageParser<C2M_Input_UseSkill>(() => (C2M_Input_UseSkill)MessagePool.Instance.Fetch(typeof(C2M_Input_UseSkill)));
+    public static pb::MessageParser<C2M_Input_UseSkill> Parser { get { return _parser; } }
+
+    private int rpcId_;
+    public int RpcId {
+      get { return rpcId_; }
+      set {
+        rpcId_ = value;
+      }
+    }
+
+    private long actorId_;
+    public long ActorId {
+      get { return actorId_; }
+      set {
+        actorId_ = value;
+      }
+    }
+
+    private long id_;
+    public long Id {
+      get { return id_; }
+      set {
+        id_ = value;
+      }
+    }
+
+    private long unitId_;
+    public long UnitId {
+      get { return unitId_; }
+      set {
+        unitId_ = value;
+      }
+    }
+
+    private long targetId_;
+    public long TargetId {
+      get { return targetId_; }
+      set {
+        targetId_ = value;
+      }
+    }
+
+    private int frame_;
+    public int Frame {
+      get { return frame_; }
+      set {
+        frame_ = value;
+      }
+    }
+
+    private int skillId_;
+    public int SkillId {
+      get { return skillId_; }
+      set {
+        skillId_ = value;
+      }
+    }
+
+    private global::ETModel.Vector3Info direction_;
+    public global::ETModel.Vector3Info Direction {
+      get { return direction_; }
+      set {
+        direction_ = value;
+      }
+    }
+
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (UnitId != 0L) {
+        output.WriteRawTag(8);
+        output.WriteInt64(UnitId);
+      }
+      if (TargetId != 0L) {
+        output.WriteRawTag(16);
+        output.WriteInt64(TargetId);
+      }
+      if (Frame != 0) {
+        output.WriteRawTag(24);
+        output.WriteInt32(Frame);
+      }
+      if (SkillId != 0) {
+        output.WriteRawTag(32);
+        output.WriteInt32(SkillId);
+      }
+      if (direction_ != null) {
+        output.WriteRawTag(42);
+        output.WriteMessage(Direction);
+      }
+      if (RpcId != 0) {
+        output.WriteRawTag(208, 5);
+        output.WriteInt32(RpcId);
+      }
+      if (ActorId != 0L) {
+        output.WriteRawTag(232, 5);
+        output.WriteInt64(ActorId);
+      }
+      if (Id != 0L) {
+        output.WriteRawTag(240, 5);
+        output.WriteInt64(Id);
+      }
+    }
+
+    public int CalculateSize() {
+      int size = 0;
+      if (RpcId != 0) {
+        size += 2 + pb::CodedOutputStream.ComputeInt32Size(RpcId);
+      }
+      if (ActorId != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(ActorId);
+      }
+      if (Id != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(Id);
+      }
+      if (UnitId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(UnitId);
+      }
+      if (TargetId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(TargetId);
+      }
+      if (Frame != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Frame);
+      }
+      if (SkillId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(SkillId);
+      }
+      if (direction_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Direction);
+      }
+      return size;
+    }
+
+    public void MergeFrom(pb::CodedInputStream input) {
+      unitId_ = 0;
+      targetId_ = 0;
+      frame_ = 0;
+      skillId_ = 0;
+      if (direction_ != null) MessagePool.Instance.Recycle(direction_); direction_ = null;
+      rpcId_ = 0;
+      actorId_ = 0;
+      id_ = 0;
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 8: {
+            UnitId = input.ReadInt64();
+            break;
+          }
+          case 16: {
+            TargetId = input.ReadInt64();
+            break;
+          }
+          case 24: {
+            Frame = input.ReadInt32();
+            break;
+          }
+          case 32: {
+            SkillId = input.ReadInt32();
+            break;
+          }
+          case 42: {
+            if (direction_ == null) {
+              direction_ = new global::ETModel.Vector3Info();
+            }
+            input.ReadMessage(direction_);
+            break;
+          }
+          case 720: {
+            RpcId = input.ReadInt32();
+            break;
+          }
+          case 744: {
+            ActorId = input.ReadInt64();
+            break;
+          }
+          case 752: {
+            Id = input.ReadInt64();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public partial class M2C_Result_UseSkill : pb::IMessage {
+    private static readonly pb::MessageParser<M2C_Result_UseSkill> _parser = new pb::MessageParser<M2C_Result_UseSkill>(() => (M2C_Result_UseSkill)MessagePool.Instance.Fetch(typeof(M2C_Result_UseSkill)));
+    public static pb::MessageParser<M2C_Result_UseSkill> Parser { get { return _parser; } }
+
+    private long actorId_;
+    public long ActorId {
+      get { return actorId_; }
+      set {
+        actorId_ = value;
+      }
+    }
+
+    private long id_;
+    public long Id {
+      get { return id_; }
+      set {
+        id_ = value;
+      }
+    }
+
+    private long unitId_;
+    public long UnitId {
+      get { return unitId_; }
+      set {
+        unitId_ = value;
+      }
+    }
+
+    private int skillId_;
+    public int SkillId {
+      get { return skillId_; }
+      set {
+        skillId_ = value;
+      }
+    }
+
+    private long targetId_;
+    public long TargetId {
+      get { return targetId_; }
+      set {
+        targetId_ = value;
+      }
+    }
+
+    private int frame_;
+    public int Frame {
+      get { return frame_; }
+      set {
+        frame_ = value;
+      }
+    }
+
+    private bool success_;
+    public bool Success {
+      get { return success_; }
+      set {
+        success_ = value;
+      }
+    }
+
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (UnitId != 0L) {
+        output.WriteRawTag(8);
+        output.WriteInt64(UnitId);
+      }
+      if (SkillId != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(SkillId);
+      }
+      if (TargetId != 0L) {
+        output.WriteRawTag(24);
+        output.WriteInt64(TargetId);
+      }
+      if (Frame != 0) {
+        output.WriteRawTag(32);
+        output.WriteInt32(Frame);
+      }
+      if (Success != false) {
+        output.WriteRawTag(40);
+        output.WriteBool(Success);
+      }
+      if (ActorId != 0L) {
+        output.WriteRawTag(232, 5);
+        output.WriteInt64(ActorId);
+      }
+      if (Id != 0L) {
+        output.WriteRawTag(240, 5);
+        output.WriteInt64(Id);
+      }
+    }
+
+    public int CalculateSize() {
+      int size = 0;
+      if (ActorId != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(ActorId);
+      }
+      if (Id != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(Id);
+      }
+      if (UnitId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(UnitId);
+      }
+      if (SkillId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(SkillId);
+      }
+      if (TargetId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(TargetId);
+      }
+      if (Frame != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Frame);
+      }
+      if (Success != false) {
+        size += 1 + 1;
+      }
+      return size;
+    }
+
+    public void MergeFrom(pb::CodedInputStream input) {
+      unitId_ = 0;
+      skillId_ = 0;
+      targetId_ = 0;
+      frame_ = 0;
+      success_ = false;
+      actorId_ = 0;
+      id_ = 0;
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 8: {
+            UnitId = input.ReadInt64();
+            break;
+          }
+          case 16: {
+            SkillId = input.ReadInt32();
+            break;
+          }
+          case 24: {
+            TargetId = input.ReadInt64();
+            break;
+          }
+          case 32: {
+            Frame = input.ReadInt32();
+            break;
+          }
+          case 40: {
+            Success = input.ReadBool();
+            break;
+          }
+          case 744: {
+            ActorId = input.ReadInt64();
+            break;
+          }
+          case 752: {
+            Id = input.ReadInt64();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public partial class M2C_StartSkill : pb::IMessage {
+    private static readonly pb::MessageParser<M2C_StartSkill> _parser = new pb::MessageParser<M2C_StartSkill>(() => (M2C_StartSkill)MessagePool.Instance.Fetch(typeof(M2C_StartSkill)));
+    public static pb::MessageParser<M2C_StartSkill> Parser { get { return _parser; } }
+
+    private long actorId_;
+    public long ActorId {
+      get { return actorId_; }
+      set {
+        actorId_ = value;
+      }
+    }
+
+    private long id_;
+    public long Id {
+      get { return id_; }
+      set {
+        id_ = value;
+      }
+    }
+
+    private long unitId_;
+    public long UnitId {
+      get { return unitId_; }
+      set {
+        unitId_ = value;
+      }
+    }
+
+    private int skillId_;
+    public int SkillId {
+      get { return skillId_; }
+      set {
+        skillId_ = value;
+      }
+    }
+
+    private long targetId_;
+    public long TargetId {
+      get { return targetId_; }
+      set {
+        targetId_ = value;
+      }
+    }
+
+    private int frame_;
+    public int Frame {
+      get { return frame_; }
+      set {
+        frame_ = value;
+      }
+    }
+
+    private global::ETModel.Vector3Info direction_;
+    public global::ETModel.Vector3Info Direction {
+      get { return direction_; }
+      set {
+        direction_ = value;
+      }
+    }
+
+    private string state_ = "";
+    public string State {
+      get { return state_; }
+      set {
+        state_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (UnitId != 0L) {
+        output.WriteRawTag(8);
+        output.WriteInt64(UnitId);
+      }
+      if (SkillId != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(SkillId);
+      }
+      if (TargetId != 0L) {
+        output.WriteRawTag(24);
+        output.WriteInt64(TargetId);
+      }
+      if (Frame != 0) {
+        output.WriteRawTag(32);
+        output.WriteInt32(Frame);
+      }
+      if (direction_ != null) {
+        output.WriteRawTag(42);
+        output.WriteMessage(Direction);
+      }
+      if (State.Length != 0) {
+        output.WriteRawTag(50);
+        output.WriteString(State);
+      }
+      if (ActorId != 0L) {
+        output.WriteRawTag(232, 5);
+        output.WriteInt64(ActorId);
+      }
+      if (Id != 0L) {
+        output.WriteRawTag(240, 5);
+        output.WriteInt64(Id);
+      }
+    }
+
+    public int CalculateSize() {
+      int size = 0;
+      if (ActorId != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(ActorId);
+      }
+      if (Id != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(Id);
+      }
+      if (UnitId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(UnitId);
+      }
+      if (SkillId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(SkillId);
+      }
+      if (TargetId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(TargetId);
+      }
+      if (Frame != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Frame);
+      }
+      if (direction_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Direction);
+      }
+      if (State.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(State);
+      }
+      return size;
+    }
+
+    public void MergeFrom(pb::CodedInputStream input) {
+      unitId_ = 0;
+      skillId_ = 0;
+      targetId_ = 0;
+      frame_ = 0;
+      if (direction_ != null) MessagePool.Instance.Recycle(direction_); direction_ = null;
+      state_ = "";
+      actorId_ = 0;
+      id_ = 0;
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 8: {
+            UnitId = input.ReadInt64();
+            break;
+          }
+          case 16: {
+            SkillId = input.ReadInt32();
+            break;
+          }
+          case 24: {
+            TargetId = input.ReadInt64();
+            break;
+          }
+          case 32: {
+            Frame = input.ReadInt32();
+            break;
+          }
+          case 42: {
+            if (direction_ == null) {
+              direction_ = new global::ETModel.Vector3Info();
+            }
+            input.ReadMessage(direction_);
+            break;
+          }
+          case 50: {
+            State = input.ReadString();
+            break;
+          }
+          case 744: {
+            ActorId = input.ReadInt64();
+            break;
+          }
+          case 752: {
+            Id = input.ReadInt64();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public partial class M2C_FinishSkill : pb::IMessage {
+    private static readonly pb::MessageParser<M2C_FinishSkill> _parser = new pb::MessageParser<M2C_FinishSkill>(() => (M2C_FinishSkill)MessagePool.Instance.Fetch(typeof(M2C_FinishSkill)));
+    public static pb::MessageParser<M2C_FinishSkill> Parser { get { return _parser; } }
+
+    private long actorId_;
+    public long ActorId {
+      get { return actorId_; }
+      set {
+        actorId_ = value;
+      }
+    }
+
+    private long id_;
+    public long Id {
+      get { return id_; }
+      set {
+        id_ = value;
+      }
+    }
+
+    private long unitId_;
+    public long UnitId {
+      get { return unitId_; }
+      set {
+        unitId_ = value;
+      }
+    }
+
+    private int frame_;
+    public int Frame {
+      get { return frame_; }
+      set {
+        frame_ = value;
+      }
+    }
+
+    private int skillId_;
+    public int SkillId {
+      get { return skillId_; }
+      set {
+        skillId_ = value;
+      }
+    }
+
+    private int damage_;
+    public int Damage {
+      get { return damage_; }
+      set {
+        damage_ = value;
+      }
+    }
+
+    private string state_ = "";
+    public string State {
+      get { return state_; }
+      set {
+        state_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    public void WriteTo(pb::CodedOutputStream output) {
+      if (UnitId != 0L) {
+        output.WriteRawTag(8);
+        output.WriteInt64(UnitId);
+      }
+      if (Frame != 0) {
+        output.WriteRawTag(16);
+        output.WriteInt32(Frame);
+      }
+      if (SkillId != 0) {
+        output.WriteRawTag(24);
+        output.WriteInt32(SkillId);
+      }
+      if (Damage != 0) {
+        output.WriteRawTag(32);
+        output.WriteInt32(Damage);
+      }
+      if (State.Length != 0) {
+        output.WriteRawTag(42);
+        output.WriteString(State);
+      }
+      if (ActorId != 0L) {
+        output.WriteRawTag(232, 5);
+        output.WriteInt64(ActorId);
+      }
+      if (Id != 0L) {
+        output.WriteRawTag(240, 5);
+        output.WriteInt64(Id);
+      }
+    }
+
+    public int CalculateSize() {
+      int size = 0;
+      if (ActorId != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(ActorId);
+      }
+      if (Id != 0L) {
+        size += 2 + pb::CodedOutputStream.ComputeInt64Size(Id);
+      }
+      if (UnitId != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeInt64Size(UnitId);
+      }
+      if (Frame != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Frame);
+      }
+      if (SkillId != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(SkillId);
+      }
+      if (Damage != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Damage);
+      }
+      if (State.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(State);
+      }
+      return size;
+    }
+
+    public void MergeFrom(pb::CodedInputStream input) {
+      unitId_ = 0;
+      frame_ = 0;
+      skillId_ = 0;
+      damage_ = 0;
+      state_ = "";
+      actorId_ = 0;
+      id_ = 0;
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+        switch(tag) {
+          default:
+            input.SkipLastField();
+            break;
+          case 8: {
+            UnitId = input.ReadInt64();
+            break;
+          }
+          case 16: {
+            Frame = input.ReadInt32();
+            break;
+          }
+          case 24: {
+            SkillId = input.ReadInt32();
+            break;
+          }
+          case 32: {
+            Damage = input.ReadInt32();
+            break;
+          }
+          case 42: {
+            State = input.ReadString();
+            break;
+          }
+          case 744: {
+            ActorId = input.ReadInt64();
+            break;
+          }
+          case 752: {
+            Id = input.ReadInt64();
+            break;
+          }
+        }
+      }
+    }
+
+  }
+
+  public partial class Vector3Info : pb::IMessage {
+    private static readonly pb::MessageParser<Vector3Info> _parser = new pb::MessageParser<Vector3Info>(() => (Vector3Info)MessagePool.Instance.Fetch(typeof(Vector3Info)));
+    public static pb::MessageParser<Vector3Info> Parser { get { return _parser; } }
 
     private float x_;
     public float X {
@@ -604,57 +1927,22 @@ namespace ETModel {
     }
 
     public void WriteTo(pb::CodedOutputStream output) {
-      if (UnitId != 0L) {
-        output.WriteRawTag(8);
-        output.WriteInt64(UnitId);
-      }
-      if (Route.Length != 0) {
-        output.WriteRawTag(18);
-        output.WriteBytes(Route);
-      }
-      if (YRotation != 0F) {
-        output.WriteRawTag(29);
-        output.WriteFloat(YRotation);
-      }
-      if (State != 0) {
-        output.WriteRawTag(32);
-        output.WriteEnum((int) State);
-      }
-      if (Frame != 0) {
-        output.WriteRawTag(40);
-        output.WriteInt32(Frame);
-      }
       if (X != 0F) {
-        output.WriteRawTag(53);
+        output.WriteRawTag(13);
         output.WriteFloat(X);
       }
       if (Y != 0F) {
-        output.WriteRawTag(61);
+        output.WriteRawTag(21);
         output.WriteFloat(Y);
       }
       if (Z != 0F) {
-        output.WriteRawTag(69);
+        output.WriteRawTag(29);
         output.WriteFloat(Z);
       }
     }
 
     public int CalculateSize() {
       int size = 0;
-      if (UnitId != 0L) {
-        size += 1 + pb::CodedOutputStream.ComputeInt64Size(UnitId);
-      }
-      if (Route.Length != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeBytesSize(Route);
-      }
-      if (YRotation != 0F) {
-        size += 1 + 4;
-      }
-      if (State != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) State);
-      }
-      if (Frame != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeInt32Size(Frame);
-      }
       if (X != 0F) {
         size += 1 + 4;
       }
@@ -668,9 +1956,6 @@ namespace ETModel {
     }
 
     public void MergeFrom(pb::CodedInputStream input) {
-      unitId_ = 0;
-      yRotation_ = 0f;
-      frame_ = 0;
       x_ = 0f;
       y_ = 0f;
       z_ = 0f;
@@ -680,35 +1965,15 @@ namespace ETModel {
           default:
             input.SkipLastField();
             break;
-          case 8: {
-            UnitId = input.ReadInt64();
-            break;
-          }
-          case 18: {
-            Route = input.ReadBytes();
-            break;
-          }
-          case 29: {
-            YRotation = input.ReadFloat();
-            break;
-          }
-          case 32: {
-            state_ = (global::ETModel.StateInfo) input.ReadEnum();
-            break;
-          }
-          case 40: {
-            Frame = input.ReadInt32();
-            break;
-          }
-          case 53: {
+          case 13: {
             X = input.ReadFloat();
             break;
           }
-          case 61: {
+          case 21: {
             Y = input.ReadFloat();
             break;
           }
-          case 69: {
+          case 29: {
             Z = input.ReadFloat();
             break;
           }

--- a/MMOServer/Server/ET.Core/Module/Message/OuterOpcode.cs
+++ b/MMOServer/Server/ET.Core/Module/Message/OuterOpcode.cs
@@ -13,14 +13,38 @@ namespace ETModel
 	[Message(OuterOpcode.CreateUnits_M2C)]
 	public partial class CreateUnits_M2C : IActorMessage {}
 
-	[Message(OuterOpcode.Sync_MoveMessage)]
-	public partial class Sync_MoveMessage : IActorMessage {}
+	[Message(OuterOpcode.C2M_SelectTarget)]
+	public partial class C2M_SelectTarget : IActorLocationMessage {}
 
-	[Message(OuterOpcode.State_FrameMessage)]
-	public partial class State_FrameMessage : IActorLocationMessage {}
+	[Message(OuterOpcode.M2C_SelectTarget)]
+	public partial class M2C_SelectTarget : IActorMessage {}
 
-	[Message(OuterOpcode.MoveInfo)]
-	public partial class MoveInfo {}
+	[Message(OuterOpcode.M2C_CreateSprites)]
+	public partial class M2C_CreateSprites : IActorMessage {}
+
+	[Message(OuterOpcode.SpriteInfo)]
+	public partial class SpriteInfo {}
+
+	[Message(OuterOpcode.C2M_Input_Move)]
+	public partial class C2M_Input_Move : IActorLocationMessage {}
+
+	[Message(OuterOpcode.M2C_Result_Move)]
+	public partial class M2C_Result_Move : IActorMessage {}
+
+	[Message(OuterOpcode.C2M_Input_UseSkill)]
+	public partial class C2M_Input_UseSkill : IActorLocationMessage {}
+
+	[Message(OuterOpcode.M2C_Result_UseSkill)]
+	public partial class M2C_Result_UseSkill : IActorMessage {}
+
+	[Message(OuterOpcode.M2C_StartSkill)]
+	public partial class M2C_StartSkill : IActorMessage {}
+
+	[Message(OuterOpcode.M2C_FinishSkill)]
+	public partial class M2C_FinishSkill : IActorMessage {}
+
+	[Message(OuterOpcode.Vector3Info)]
+	public partial class Vector3Info {}
 
 //获取大厅玩家信息请求
 	[Message(OuterOpcode.GetUserInfo_InLobby_C2G)]
@@ -89,27 +113,35 @@ namespace ETModel
 		 public const ushort EnterMap_C2G = 101;
 		 public const ushort EnterMap_G2C = 102;
 		 public const ushort CreateUnits_M2C = 103;
-		 public const ushort Sync_MoveMessage = 104;
-		 public const ushort State_FrameMessage = 105;
-		 public const ushort MoveInfo = 106;
-		 public const ushort GetUserInfo_InLobby_C2G = 107;
-		 public const ushort GetUserInfo_InLobby_G2C = 108;
-		 public const ushort Actor_Test = 109;
-		 public const ushort C2M_TestRequest = 110;
-		 public const ushort M2C_TestResponse = 111;
-		 public const ushort Actor_TransferRequest = 112;
-		 public const ushort Actor_TransferResponse = 113;
-		 public const ushort C2G_EnterMap = 114;
-		 public const ushort G2C_EnterMap = 115;
-		 public const ushort UnitInfo = 116;
-		 public const ushort M2C_CreateUnits = 117;
-		 public const ushort Frame_ClickMap = 118;
-		 public const ushort State_ClickMap = 119;
-		 public const ushort M2C_PathfindingResult = 120;
-		 public const ushort C2R_Ping = 121;
-		 public const ushort R2C_Ping = 122;
-		 public const ushort G2C_Test = 123;
-		 public const ushort C2M_Reload = 124;
-		 public const ushort M2C_Reload = 125;
+		 public const ushort C2M_SelectTarget = 104;
+		 public const ushort M2C_SelectTarget = 105;
+		 public const ushort M2C_CreateSprites = 106;
+		 public const ushort SpriteInfo = 107;
+		 public const ushort C2M_Input_Move = 108;
+		 public const ushort M2C_Result_Move = 109;
+		 public const ushort C2M_Input_UseSkill = 110;
+		 public const ushort M2C_Result_UseSkill = 111;
+		 public const ushort M2C_StartSkill = 112;
+		 public const ushort M2C_FinishSkill = 113;
+		 public const ushort Vector3Info = 114;
+		 public const ushort GetUserInfo_InLobby_C2G = 115;
+		 public const ushort GetUserInfo_InLobby_G2C = 116;
+		 public const ushort Actor_Test = 117;
+		 public const ushort C2M_TestRequest = 118;
+		 public const ushort M2C_TestResponse = 119;
+		 public const ushort Actor_TransferRequest = 120;
+		 public const ushort Actor_TransferResponse = 121;
+		 public const ushort C2G_EnterMap = 122;
+		 public const ushort G2C_EnterMap = 123;
+		 public const ushort UnitInfo = 124;
+		 public const ushort M2C_CreateUnits = 125;
+		 public const ushort Frame_ClickMap = 126;
+		 public const ushort State_ClickMap = 127;
+		 public const ushort M2C_PathfindingResult = 128;
+		 public const ushort C2R_Ping = 129;
+		 public const ushort R2C_Ping = 130;
+		 public const ushort G2C_Test = 131;
+		 public const ushort C2M_Reload = 132;
+		 public const ushort M2C_Reload = 133;
 	}
 }


### PR DESCRIPTION
1 增加Bounds类用于在服务器上设置角色的中心
2 Vector3与四元素类中增加了方法用于服务端计算移动与角度
3 增加技能同步需要的消息类